### PR TITLE
Various Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,16 @@
 
 FLAGS := -quiet
 BUILD := build
-SRC :=  lecture1.tex \
-	lecture2.tex \
-	lecture3.tex \
-	lecture4.tex \
-	lecture5.tex \
-	lecture6.tex \
-	lecture7.tex \
-	lecture8.tex \
-	lecture9.tex
+SRC := lecture1.tex \
+       lecture2.tex \
+       lecture3.tex \
+       lecture4.tex \
+       lecture5.tex \
+       lecture6.tex \
+       lecture7.tex \
+       lecture8.tex \
+       lecture9.tex
+
 SRC_DIR := tex
 SRC := $(addprefix $(SRC_DIR)/,$(SRC))
 TARGETS := acs-category-theory-notes.pdf

--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,18 @@ SRC := lecture1.tex \
 
 SRC_DIR := tex
 SRC := $(addprefix $(SRC_DIR)/,$(SRC))
+BUILD_AUX := $(BUILD)/$(SRC_DIR)
 TARGETS := acs-category-theory-notes.pdf
 
 all: $(TARGETS)
 
-%.pdf: %.tex $(SRC) | $(BUILD)
+%.pdf: %.tex $(SRC) | $(BUILD) $(BUILD_AUX)
 	latexmk -pdf -output-directory=$(BUILD) -pdflatex="pdflatex -interaction=nonstopmode" $< $(FLAGS) > build.log
 	mv $(BUILD)/$@ ./$@
 
-$(BUILD):
-	mkdir -p $(BUILD)
+$(BUILD_AUX): $(BUILD)
+$(BUILD) $(BUILD_AUX): %:
+	mkdir -p $@
 
 clean:
 	git clean -xfd $(foreach target, $(TARGETS), --exclude="$(target)")

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SRC := $(addprefix $(SRC_DIR)/,$(SRC))
 BUILD_AUX := $(BUILD)/$(SRC_DIR)
 TARGETS := acs-category-theory-notes.pdf
 
+.PHONY: all
 all: $(TARGETS)
 
 %.pdf: %.tex $(SRC) | $(BUILD) $(BUILD_AUX)
@@ -27,5 +28,6 @@ $(BUILD_AUX): $(BUILD)
 $(BUILD) $(BUILD_AUX): %:
 	mkdir -p $@
 
+.PHONY: clean
 clean:
 	git clean -xfd $(foreach target, $(TARGETS), --exclude="$(target)")


### PR DESCRIPTION
The important commit is the second one, which ensures the `build/tex` directory exists prior to running `latexmk`, since for every `.tex` file (including those included with `\include`), the corresponding `.aux` file goes in `$(OUTPUT_DIRECTORY)/$(dirname $file)`.

Out of interest, why does the `clean` target not delete the actual PDF? It's somewhat surprising that cleaning and re-running make only recreates the output directory hierarchy and then stops (since the target PDF still exists and is newer than the source `.tex` files), rather than going and rebuilding. Normally `clean` would also delete the output...